### PR TITLE
feat(ui): Join Space UI

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import SpaceNew from "./pages/SpaceNew";
 import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 import HomeChoice from "./pages/HomeChoice";
 import GiftList from "./pages/GiftList";
+import SpaceJoin from "./pages/SpaceJoin";
 
 interface User {
   id: number;
@@ -65,6 +66,7 @@ function App() {
         {/* Temporary HomeChoice route for Issue #3 */}
         <Route path="/" element={<HomeChoice />} />
         <Route path="/space/new" element={<SpaceNew />} />
+        <Route path="/space/join" element={<SpaceJoin />} />
         <Route path="/space/:id/gifts" element={<GiftList />} />
 
 

--- a/src/components/JoinCodeInput.tsx
+++ b/src/components/JoinCodeInput.tsx
@@ -1,0 +1,241 @@
+import { ChangeEvent, useId, useState } from "react";
+
+export const JOIN_CODE_MIN = 6;
+export const JOIN_CODE_MAX = 10;
+
+export interface JoinCodeValidationResult {
+  cleaned: string;
+  isValid: boolean;
+  message: string;
+}
+
+export function normalizeJoinCodeInput(raw: string): string {
+  if (!raw) {
+    return "";
+  }
+
+  const upper = raw.toUpperCase();
+  let normalized = "";
+  let hyphenCount = 0;
+
+  for (const char of upper) {
+    if (char === "-") {
+      if (hyphenCount > 0) {
+        continue;
+      }
+      hyphenCount += 1;
+    } else if (!/[A-Z0-9]/.test(char)) {
+      continue;
+    }
+
+    if ((normalized + char).length > JOIN_CODE_MAX) {
+      break;
+    }
+
+    normalized += char;
+  }
+
+  return normalized;
+}
+
+export function validateJoinCode(raw: string): JoinCodeValidationResult {
+  const cleaned = raw.trim().toUpperCase();
+
+  if (!cleaned) {
+    return {
+      cleaned: "",
+      isValid: false,
+      message: "Enter the invite code you received.",
+    };
+  }
+
+  if (cleaned.length < JOIN_CODE_MIN) {
+    return {
+      cleaned,
+      isValid: false,
+      message: `Code must be at least ${JOIN_CODE_MIN} characters.`,
+    };
+  }
+
+  if (cleaned.length > JOIN_CODE_MAX) {
+    return {
+      cleaned,
+      isValid: false,
+      message: `Code must be ${JOIN_CODE_MAX} characters or fewer.`,
+    };
+  }
+
+  if (!/^[A-Z0-9-]+$/.test(cleaned)) {
+    return {
+      cleaned,
+      isValid: false,
+      message: "Use capital letters, numbers, or a single hyphen.",
+    };
+  }
+
+  const hyphenMatches = cleaned.match(/-/g);
+  if (hyphenMatches && hyphenMatches.length > 1) {
+    return {
+      cleaned,
+      isValid: false,
+      message: "Only one hyphen is supported in invite codes.",
+    };
+  }
+
+  if (cleaned.startsWith("-") || cleaned.endsWith("-")) {
+    return {
+      cleaned,
+      isValid: false,
+      message: "Place the hyphen between characters.",
+    };
+  }
+
+  return { cleaned, isValid: true, message: "" };
+}
+
+const HINT_COPY =
+  "Invite codes use 6-10 characters with uppercase letters or numbers. One hyphen is optional.";
+
+interface JoinCodeInputProps {
+  value: string;
+  onChange: (value: string) => void;
+  onBlur?: () => void;
+  disabled?: boolean;
+  error?: string;
+  hint?: string;
+  label?: string;
+}
+
+export default function JoinCodeInput({
+  value,
+  onChange,
+  onBlur,
+  disabled,
+  error,
+  hint = HINT_COPY,
+  label = "Invite code",
+}: JoinCodeInputProps) {
+  const inputId = useId();
+  const hintId = `${inputId}-hint`;
+  const errorId = `${inputId}-error`;
+  const [isHovered, setIsHovered] = useState(false);
+  const [isFocused, setIsFocused] = useState(false);
+
+  const describedBy = [hint ? hintId : undefined, error ? errorId : undefined]
+    .filter(Boolean)
+    .join(" ");
+
+  const controlBorderColor = error
+    ? "var(--color-danger)"
+    : isFocused
+      ? "var(--color-accent)"
+      : isHovered
+        ? "var(--color-text)"
+        : "var(--color-border)";
+
+  function handleChange(event: ChangeEvent<HTMLInputElement>) {
+    onChange(normalizeJoinCodeInput(event.target.value));
+  }
+
+  function handleBlur() {
+    setIsFocused(false);
+    onBlur?.();
+  }
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-2)" }}>
+      <label
+        htmlFor={inputId}
+        style={{
+          fontWeight: "var(--h3-weight)",
+          color: "var(--color-text)",
+          display: "flex",
+          alignItems: "center",
+          gap: "var(--space-1)",
+        }}
+      >
+        {label}
+        <span aria-hidden="true" style={{ color: "var(--color-accent)" }}>
+          *
+        </span>
+      </label>
+
+      <div
+        onMouseEnter={() => setIsHovered(true)}
+        onMouseLeave={() => setIsHovered(false)}
+        style={{
+          border: `1px solid ${controlBorderColor}`,
+          borderRadius: "var(--radius-md)",
+          background: "var(--color-surface)",
+          padding: "0 var(--space-4)",
+          minHeight: "52px",
+          display: "flex",
+          alignItems: "center",
+          transition: "border-color var(--dur-med) var(--ease), box-shadow var(--dur-med) var(--ease)",
+          boxShadow: isFocused ? "0 0 0 2px var(--focus-ring)" : isHovered ? "var(--elev-1)" : "none",
+        }}
+      >
+        <input
+          id={inputId}
+          type="text"
+          inputMode="text"
+          autoComplete="off"
+          autoCorrect="off"
+          spellCheck={false}
+          enterKeyHint="go"
+          value={value}
+          onChange={handleChange}
+          onFocus={() => setIsFocused(true)}
+          onBlur={handleBlur}
+          disabled={disabled}
+          required
+          aria-invalid={error ? true : undefined}
+          aria-describedby={describedBy || undefined}
+          aria-required="true"
+          maxLength={JOIN_CODE_MAX}
+          style={{
+            border: "none",
+            background: "transparent",
+            width: "100%",
+            font: "inherit",
+            fontWeight: "var(--h3-weight)",
+            letterSpacing: "0.08em",
+            textTransform: "uppercase",
+            color: "var(--color-text)",
+            padding: "var(--space-2) 0",
+            outline: "none",
+          }}
+        />
+      </div>
+
+      {hint && (
+        <p
+          id={hintId}
+          style={{
+            margin: 0,
+            fontSize: "var(--caption-size)",
+            fontWeight: "var(--caption-weight)",
+            color: "var(--color-text-muted)",
+          }}
+        >
+          {hint}
+        </p>
+      )}
+
+      {error && (
+        <p
+          id={errorId}
+          role="alert"
+          style={{
+            margin: 0,
+            fontSize: "var(--caption-size)",
+            fontWeight: "var(--caption-weight)",
+            color: "var(--color-danger)",
+          }}
+        >
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/pages/HomeChoice.tsx
+++ b/src/pages/HomeChoice.tsx
@@ -1,7 +1,11 @@
+import { useId } from "react";
 import { Link } from "react-router-dom";
 import "./HomeChoice.css";
 
 export default function HomeChoice() {
+  const createCopyId = useId();
+  const joinCopyId = useId();
+
   return (
     <main className="home-choice">
       <section
@@ -23,9 +27,10 @@ export default function HomeChoice() {
           <Link
             to="/space/new"
             className="home-choice__action home-choice__action--primary"
+            aria-describedby={createCopyId}
           >
             <span className="home-choice__action-label">Create New List</span>
-            <span className="home-choice__action-copy">
+            <span id={createCopyId} className="home-choice__action-copy">
               Start fresh, pick your point rules, and invite your people.
             </span>
           </Link>
@@ -33,10 +38,11 @@ export default function HomeChoice() {
           <Link
             to="/space/join"
             className="home-choice__action home-choice__action--secondary"
+            aria-describedby={joinCopyId}
           >
             <span className="home-choice__action-label">Join Active List</span>
-            <span className="home-choice__action-copy">
-              Already invited? Enter your code and jump into the space.
+            <span id={joinCopyId} className="home-choice__action-copy">
+              Already invited? Enter your code and jump into the space, or preview the flow before you join.
             </span>
           </Link>
         </div>

--- a/src/pages/SpaceJoin.tsx
+++ b/src/pages/SpaceJoin.tsx
@@ -1,0 +1,284 @@
+import { FormEvent, useEffect, useRef, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import JoinCodeInput, { validateJoinCode } from "../components/JoinCodeInput";
+
+type Status =
+  | { type: "idle" }
+  | { type: "info"; message: string }
+  | { type: "error"; message: string };
+
+const SCREENSHOT_URL = "https://github.com/noahflewelling/giftlink/wiki/SpaceJoin-Preview";
+const SAMPLE_CODES = ["GL-8273", "739402"];
+
+const pageStyle = {
+  minHeight: "100vh",
+  background: "var(--color-bg)",
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  padding: "var(--space-12) var(--space-4)",
+};
+
+const panelStyle = {
+  width: "100%",
+  maxWidth: "640px",
+  background: "var(--color-surface)",
+  border: "1px solid var(--color-border)",
+  borderRadius: "var(--radius-lg)",
+  padding: "var(--space-8)",
+  display: "flex",
+  flexDirection: "column",
+  gap: "var(--space-6)",
+  transition: "box-shadow var(--dur-med) var(--ease), transform var(--dur-med) var(--ease)",
+};
+
+const headerStyle = {
+  display: "flex",
+  flexDirection: "column",
+  gap: "var(--space-2)",
+};
+
+const formStyle = {
+  display: "flex",
+  flexDirection: "column",
+  gap: "var(--space-4)",
+};
+
+const exampleSectionStyle = {
+  border: "1px solid var(--color-border)",
+  borderRadius: "var(--radius-md)",
+  padding: "var(--space-4)",
+  background: "var(--color-bg)",
+  display: "flex",
+  flexDirection: "column",
+  gap: "var(--space-3)",
+};
+
+export default function SpaceJoin() {
+  const navigate = useNavigate();
+  const [inviteCode, setInviteCode] = useState("");
+  const [touched, setTouched] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [panelHovered, setPanelHovered] = useState(false);
+  const [buttonHovered, setButtonHovered] = useState(false);
+  const [buttonFocused, setButtonFocused] = useState(false);
+  const [status, setStatus] = useState<Status>({ type: "idle" });
+  const [exampleLinkFocused, setExampleLinkFocused] = useState(false);
+  const pendingRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (pendingRef.current) {
+        window.clearTimeout(pendingRef.current);
+      }
+    };
+  }, []);
+
+  const validation = validateJoinCode(inviteCode);
+  const isValid = validation.isValid;
+  const inlineError = touched && !validation.isValid ? validation.message : "";
+
+  const statusId = status.type !== "idle" ? "space-join-status" : undefined;
+
+  function handleCodeChange(nextValue: string) {
+    if (status.type !== "idle") {
+      setStatus({ type: "idle" });
+    }
+    setInviteCode(nextValue);
+  }
+
+  function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setTouched(true);
+
+    if (!validation.isValid) {
+      return;
+    }
+
+    setLoading(true);
+    setStatus({ type: "info", message: "Checking invite code..." });
+
+    if (pendingRef.current) {
+      window.clearTimeout(pendingRef.current);
+    }
+
+    const cleaned = validation.cleaned;
+
+    pendingRef.current = window.setTimeout(() => {
+      pendingRef.current = null;
+
+      if (/^[0-9]+$/.test(cleaned)) {
+        navigate(`/space/${cleaned}/gifts`);
+        return;
+      }
+
+      setLoading(false);
+      setStatus({
+        type: "error",
+        message: "Invalid or unsupported code",
+      });
+    }, 350);
+  }
+
+  const buttonDisabled = !isValid || loading;
+
+  return (
+    <main style={pageStyle}>
+      <section
+        aria-labelledby="space-join-heading"
+        style={{
+          ...panelStyle,
+          boxShadow: panelHovered ? "var(--elev-2)" : "var(--elev-1)",
+          transform: panelHovered ? "translateY(-2px)" : "translateY(0)",
+        }}
+        onMouseEnter={() => setPanelHovered(true)}
+        onMouseLeave={() => setPanelHovered(false)}
+      >
+        <header style={headerStyle}>
+          <p
+            style={{
+              fontSize: "var(--caption-size)",
+              fontWeight: "var(--caption-weight)",
+              textTransform: "uppercase",
+              color: "var(--color-text-muted)",
+            }}
+          >
+            GiftLink Spaces
+          </p>
+          <h1 id="space-join-heading">Join an existing space</h1>
+          <p style={{ color: "var(--color-text-muted)", lineHeight: 1.5 }}>
+            Enter the invite code that was shared with you. We&apos;ll verify it instantly and
+            route you straight into the shared wishlist.
+          </p>
+        </header>
+
+        <form
+          style={formStyle}
+          onSubmit={handleSubmit}
+          noValidate
+          aria-describedby={statusId}
+        >
+          <JoinCodeInput
+            value={inviteCode}
+            onChange={handleCodeChange}
+            onBlur={() => setTouched(true)}
+            disabled={loading}
+            error={inlineError}
+          />
+
+          <button
+            type="submit"
+            disabled={buttonDisabled}
+            aria-busy={loading}
+            onMouseEnter={() => setButtonHovered(true)}
+            onMouseLeave={() => setButtonHovered(false)}
+            onFocus={() => setButtonFocused(true)}
+            onBlur={() => setButtonFocused(false)}
+            style={{
+              border: "none",
+              borderRadius: "var(--radius-md)",
+              padding: "0 var(--space-5)",
+              minHeight: "52px",
+              fontWeight: "var(--h3-weight)",
+              fontSize: "var(--body-size)",
+              background: buttonDisabled ? "var(--color-border)" : "var(--color-accent)",
+              color: buttonDisabled ? "var(--color-text-muted)" : "var(--color-surface)",
+              cursor: buttonDisabled ? "not-allowed" : "pointer",
+              transition:
+                "transform var(--dur-fast) var(--ease), box-shadow var(--dur-med) var(--ease), background var(--dur-med) var(--ease)",
+              boxShadow:
+                buttonDisabled || (!buttonHovered && !buttonFocused)
+                  ? "var(--elev-1)"
+                  : "var(--elev-2)",
+              transform: buttonHovered && !buttonDisabled ? "translateY(-1px)" : "translateY(0)",
+              outline: buttonFocused ? "2px solid var(--focus-ring)" : "none",
+              outlineOffset: "2px",
+            }}
+          >
+            {loading ? "Checking..." : "Continue to space"}
+          </button>
+
+          {status.type !== "idle" && (
+            <p
+              id={statusId}
+              role={status.type === "error" ? "alert" : "status"}
+              aria-live="polite"
+              style={{
+                margin: 0,
+                fontSize: "var(--caption-size)",
+                fontWeight: "var(--caption-weight)",
+                color:
+                  status.type === "error" ? "var(--color-danger)" : "var(--color-text-muted)",
+              }}
+            >
+              {status.message}
+            </p>
+          )}
+        </form>
+
+        <section
+          aria-labelledby="space-join-example-heading"
+          style={exampleSectionStyle}
+        >
+          <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-2)" }}>
+            <p
+              id="space-join-example-heading"
+              style={{
+                fontWeight: "var(--h3-weight)",
+                color: "var(--color-text)",
+                margin: 0,
+              }}
+            >
+              In-page example
+            </p>
+            <p style={{ margin: 0, color: "var(--color-text-muted)", lineHeight: 1.4 }}>
+              Try one of these sample codes to preview the validation states.
+            </p>
+            <div style={{ display: "flex", gap: "var(--space-3)", flexWrap: "wrap" }}>
+              {SAMPLE_CODES.map((code) => (
+                <span
+                  key={code}
+                  style={{
+                    borderRadius: "var(--radius-sm)",
+                    padding: "var(--space-2) var(--space-3)",
+                    background: "var(--color-accent-quiet)",
+                    color: "var(--color-text)",
+                    fontWeight: "var(--h3-weight)",
+                    letterSpacing: "0.08em",
+                  }}
+                >
+                  {code}
+                </span>
+              ))}
+            </div>
+            <p style={{ margin: 0, color: "var(--color-text-muted)", fontSize: "var(--caption-size)" }}>
+              Screenshot link below shows the full flow for release notes.
+            </p>
+          </div>
+
+          <a
+            href={SCREENSHOT_URL}
+            target="_blank"
+            rel="noreferrer"
+            style={{
+              display: "inline-flex",
+              alignItems: "center",
+              gap: "var(--space-1)",
+              fontWeight: "var(--h3-weight)",
+              color: "var(--color-accent)",
+              borderRadius: "var(--radius-sm)",
+              padding: "var(--space-2) var(--space-3)",
+              minHeight: "44px",
+              outline: exampleLinkFocused ? "2px solid var(--focus-ring)" : "none",
+              outlineOffset: "2px",
+            }}
+            onFocus={() => setExampleLinkFocused(true)}
+            onBlur={() => setExampleLinkFocused(false)}
+          >
+            View latest screenshot (opens in new tab)
+          </a>
+        </section>
+      </section>
+    </main>
+  );
+}


### PR DESCRIPTION
Implements the client-side join flow per issue #<issue-number>. Adds /space/join, validation (6–10 chars, A–Z, 0–9, optional hyphen), disabled submit until valid, and stubbed submit routing.

**Checklist**
- [x] Tokens only (spacing/radius/colors/shadows)
- [x] A11y (labels, aria-describedby, role="alert", focus ring, keyboardable, ≥44px targets)
- [x] Route and page render from HomeChoice link
- [x] Stubbed behavior: numeric → /space/:id/gifts; otherwise non-blocking error
- [x] Screenshot attached

Closes #<issue-number>

<img width="651" height="704" alt="image" src="https://github.com/user-attachments/assets/b67686af-ebeb-470b-a823-25f94e95bf05" />
<img width="607" height="240" alt="image" src="https://github.com/user-attachments/assets/0997ff3a-b3cf-4bad-902d-46c495f89b23" />
<img width="715" height="853" alt="image" src="https://github.com/user-attachments/assets/e30880eb-95ab-4e80-9ca2-ca8f722df8d9" />
