### PR TITLE
feat(ui): Space Dashboard

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 import HomeChoice from "./pages/HomeChoice";
 import GiftList from "./pages/GiftList";
 import SpaceJoin from "./pages/SpaceJoin";
+import SpaceDashboard from "./pages/SpaceDashboard";
 
 interface User {
   id: number;
@@ -67,6 +68,7 @@ function App() {
         <Route path="/" element={<HomeChoice />} />
         <Route path="/space/new" element={<SpaceNew />} />
         <Route path="/space/join" element={<SpaceJoin />} />
+        <Route path="/space/:id" element={<SpaceDashboard />} />
         <Route path="/space/:id/gifts" element={<GiftList />} />
 
 

--- a/src/components/GiftListCard.tsx
+++ b/src/components/GiftListCard.tsx
@@ -1,0 +1,136 @@
+import { type CSSProperties } from "react";
+import { Link } from "react-router-dom";
+
+interface GiftListCardProps {
+  spaceId: string;
+  spaceName: string;
+  giftCount: number;
+  onAddGift: () => void;
+}
+
+const cardStyle: CSSProperties = {
+  background: "var(--color-surface)",
+  border: "1px solid var(--color-border)",
+  borderRadius: "var(--radius-md)",
+  padding: "var(--space-5)",
+  display: "flex",
+  flexDirection: "column",
+  gap: "var(--space-4)",
+  minHeight: "calc(var(--space-12) * 5)",
+};
+
+const primaryButtonStyle: CSSProperties = {
+  background: "var(--color-accent)",
+  color: "var(--color-surface)",
+  border: "none",
+  borderRadius: "var(--radius-md)",
+  padding: "0 var(--space-5)",
+  minHeight: "var(--space-12)",
+  fontSize: "var(--body-size)",
+  fontWeight: "var(--h3-weight)",
+  cursor: "pointer",
+  display: "inline-flex",
+  alignItems: "center",
+  justifyContent: "center",
+  transition: "background var(--dur-med) var(--ease), transform var(--dur-fast) var(--ease)",
+};
+
+const secondaryButtonStyle: CSSProperties = {
+  background: "var(--color-accent-quiet)",
+  color: "var(--color-accent)",
+  border: "none",
+  borderRadius: "var(--radius-md)",
+  padding: "0 var(--space-5)",
+  minHeight: "var(--space-12)",
+  fontSize: "var(--body-size)",
+  fontWeight: "var(--h3-weight)",
+  display: "inline-flex",
+  alignItems: "center",
+  justifyContent: "center",
+  transition: "background var(--dur-med) var(--ease)",
+};
+
+export default function GiftListCard({
+  giftCount,
+  onAddGift,
+  spaceId,
+  spaceName,
+}: GiftListCardProps) {
+  const hasGifts = giftCount > 0;
+
+  return (
+    <section style={cardStyle} aria-label="Gift summary">
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
+          gap: "var(--space-3)",
+          flexWrap: "wrap",
+        }}
+      >
+        <div>
+          <h2 style={{ margin: 0 }}>Gifts</h2>
+          <p
+            style={{
+              margin: 0,
+              marginTop: "var(--space-1)",
+              color: "var(--color-text-muted)",
+            }}
+          >
+            {giftCount} {giftCount === 1 ? "gift" : "gifts"}
+          </p>
+        </div>
+        <Link
+          to={`/space/${spaceId}/gifts`}
+          aria-label={`View gifts for ${spaceName}`}
+          className="focus-ring"
+          style={{
+            ...secondaryButtonStyle,
+            textDecoration: "none",
+            fontWeight: "var(--h3-weight)",
+          }}
+        >
+          View gifts
+        </Link>
+      </div>
+
+      {hasGifts ? (
+        <p
+          style={{
+            margin: 0,
+            color: "var(--color-text)",
+            lineHeight: 1.5,
+          }}
+        >
+          You're on track! Keep the list curated so members know exactly what
+          {" "}
+          {spaceName} is hoping for.
+        </p>
+      ) : (
+        <p
+          style={{
+            margin: 0,
+            color: "var(--color-text-muted)",
+            lineHeight: 1.5,
+          }}
+        >
+          No gifts yet. Add the first idea so your space has a clear starting
+          point.
+        </p>
+      )}
+
+      <div style={{ marginTop: "auto" }}>
+        <button
+          type="button"
+          onClick={onAddGift}
+          className="focus-ring"
+          style={primaryButtonStyle}
+          aria-label="Add a gift"
+        >
+          Add gift
+        </button>
+      </div>
+    </section>
+  );
+}

--- a/src/components/SpaceHeader.tsx
+++ b/src/components/SpaceHeader.tsx
@@ -1,0 +1,113 @@
+import { useState, type CSSProperties } from "react";
+
+interface SpaceHeaderProps {
+  name: string;
+  inviteCode: string;
+}
+
+const containerStyle: CSSProperties = {
+  background: "var(--color-surface)",
+  border: "1px solid var(--color-border)",
+  borderRadius: "var(--radius-lg)",
+  padding: "var(--space-6)",
+  display: "flex",
+  flexDirection: "column",
+  gap: "var(--space-4)",
+  boxShadow: "var(--elev-1)",
+};
+
+const inviteRowStyle: CSSProperties = {
+  display: "flex",
+  flexWrap: "wrap",
+  gap: "var(--space-3)",
+  alignItems: "center",
+};
+
+const copyButtonStyle: CSSProperties = {
+  background: "var(--color-accent)",
+  color: "var(--color-surface)",
+  border: "none",
+  borderRadius: "var(--radius-md)",
+  padding: "0 var(--space-5)",
+  minHeight: "var(--space-12)",
+  fontSize: "var(--body-size)",
+  fontWeight: "var(--h3-weight)",
+  cursor: "pointer",
+  transition: "background var(--dur-med) var(--ease), transform var(--dur-fast) var(--ease)",
+  display: "inline-flex",
+  alignItems: "center",
+  justifyContent: "center",
+};
+
+const statusStyle: CSSProperties = {
+  fontSize: "var(--caption-size)",
+  fontWeight: "var(--caption-weight)",
+  color: "var(--color-text-muted)",
+  minHeight: "var(--space-4)",
+};
+
+export default function SpaceHeader({ name, inviteCode }: SpaceHeaderProps) {
+  const [copyStatus, setCopyStatus] = useState<string>("");
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(inviteCode);
+      setCopyStatus("Invite code copied");
+      window.setTimeout(() => setCopyStatus(""), 2000);
+    } catch (error) {
+      console.error("Clipboard copy failed", error);
+      setCopyStatus("Unable to copy. Select and copy manually.");
+    }
+  };
+
+  return (
+    <header style={containerStyle} aria-labelledby="space-heading">
+      <div>
+        <p
+          id="space-heading"
+          style={{
+            fontSize: "var(--h1-size)",
+            fontWeight: "var(--h1-weight)",
+            margin: 0,
+          }}
+        >
+          {name}
+        </p>
+        <p
+          style={{
+            margin: 0,
+            marginTop: "var(--space-2)",
+            color: "var(--color-text-muted)",
+          }}
+        >
+          Keep everyone on the same gifting page.
+        </p>
+      </div>
+
+      <div style={inviteRowStyle}>
+        <span
+          style={{
+            fontSize: "var(--h3-size)",
+            fontWeight: "var(--h3-weight)",
+          }}
+          aria-label="Invite code"
+        >
+          {inviteCode}
+        </span>
+        <button
+          type="button"
+          className="focus-ring"
+          onClick={handleCopy}
+          style={copyButtonStyle}
+          aria-label={`Copy invite code ${inviteCode}`}
+        >
+          Copy
+        </button>
+      </div>
+
+      <div aria-live="polite" style={statusStyle}>
+        {copyStatus}
+      </div>
+    </header>
+  );
+}

--- a/src/pages/SpaceDashboard.tsx
+++ b/src/pages/SpaceDashboard.tsx
@@ -1,0 +1,216 @@
+import { useMemo, type CSSProperties } from "react";
+import { useParams } from "react-router-dom";
+import SpaceHeader from "../components/SpaceHeader";
+import GiftListCard from "../components/GiftListCard";
+
+interface SpaceMember {
+  id: string;
+  name: string;
+  initials: string;
+}
+
+interface SpaceSummary {
+  id: string;
+  name: string;
+  inviteCode: string;
+  gifts: string[];
+  members: SpaceMember[];
+}
+
+const mockSpaces: Record<string, SpaceSummary> = {
+  aurora: {
+    id: "aurora",
+    name: "Aurora Family Space",
+    inviteCode: "AUR-2024",
+    gifts: [],
+    members: [
+      { id: "1", name: "Avery Lin", initials: "AL" },
+      { id: "2", name: "Noah Diaz", initials: "ND" },
+      { id: "3", name: "Riley Chen", initials: "RC" },
+      { id: "4", name: "Maya Patel", initials: "MP" },
+    ],
+  },
+};
+
+const cardShell: CSSProperties = {
+  background: "var(--color-surface)",
+  border: "1px solid var(--color-border)",
+  borderRadius: "var(--radius-md)",
+  padding: "var(--space-5)",
+  display: "flex",
+  flexDirection: "column",
+  gap: "var(--space-4)",
+};
+
+const secondaryButton: CSSProperties = {
+  background: "var(--color-accent-quiet)",
+  color: "var(--color-accent)",
+  border: "none",
+  borderRadius: "var(--radius-md)",
+  padding: "0 var(--space-5)",
+  minHeight: "var(--space-12)",
+  fontSize: "var(--body-size)",
+  fontWeight: "var(--h3-weight)",
+  cursor: "pointer",
+  transition: "background var(--dur-med) var(--ease)",
+  display: "inline-flex",
+  alignItems: "center",
+  justifyContent: "center",
+};
+
+export default function SpaceDashboard() {
+  const { id } = useParams<{ id: string }>();
+
+  const space = useMemo(() => {
+    if (id && mockSpaces[id]) {
+      return mockSpaces[id];
+    }
+
+    return { ...mockSpaces.aurora, id: id ?? mockSpaces.aurora.id };
+  }, [id]);
+
+  const handleAddGift = () => {
+    console.info("Add gift action (stub)", space.id);
+  };
+
+  const handleInvite = () => {
+    console.info("Invite action (stub)", space.inviteCode);
+  };
+
+  const handleManageMembers = () => {
+    console.info("Manage members action (stub)", space.id);
+  };
+
+  return (
+    <main
+      style={{
+        background: "var(--color-bg)",
+        minHeight: "100vh",
+        padding: "var(--space-6)",
+      }}
+    >
+      <div
+        style={{
+          maxWidth: "1200px",
+          margin: "0 auto",
+          display: "flex",
+          flexDirection: "column",
+          gap: "var(--space-6)",
+        }}
+      >
+        <SpaceHeader name={space.name} inviteCode={space.inviteCode} />
+
+        <div
+          style={{
+            display: "grid",
+            gridTemplateColumns:
+              "repeat(auto-fit, minmax(calc(var(--space-12) * 7), 1fr))",
+            gap: "var(--space-5)",
+          }}
+        >
+          <GiftListCard
+            giftCount={space.gifts.length}
+            spaceId={space.id}
+            spaceName={space.name}
+            onAddGift={handleAddGift}
+          />
+
+          <section style={cardShell} aria-label="Members">
+            <div
+              style={{
+                display: "flex",
+                justifyContent: "space-between",
+                alignItems: "center",
+              }}
+            >
+              <div>
+                <h2 style={{ margin: 0 }}>Members</h2>
+                <p
+                  style={{
+                    margin: 0,
+                    marginTop: "var(--space-1)",
+                    color: "var(--color-text-muted)",
+                  }}
+                >
+                  {space.members.length} joined
+                </p>
+              </div>
+              <button
+                type="button"
+                className="focus-ring"
+                onClick={handleManageMembers}
+                style={secondaryButton}
+                aria-label="Manage members"
+              >
+                Manage members
+              </button>
+            </div>
+
+            <div
+              style={{
+                display: "flex",
+                gap: "var(--space-3)",
+                flexWrap: "wrap",
+              }}
+            >
+              {space.members.slice(0, 4).map((member) => (
+                <div
+                  key={member.id}
+                  title={member.name}
+                  aria-label={member.name}
+                  style={{
+                    width: "var(--space-12)",
+                    height: "var(--space-12)",
+                    borderRadius: "var(--radius-lg)",
+                    background: "var(--color-accent-quiet)",
+                    color: "var(--color-accent)",
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "center",
+                    fontWeight: "var(--h3-weight)",
+                  }}
+                >
+                  {member.initials}
+                </div>
+              ))}
+            </div>
+          </section>
+
+          <section style={cardShell} aria-label="Quick actions">
+            <h2 style={{ margin: 0 }}>Quick actions</h2>
+            <div
+              style={{
+                display: "flex",
+                flexDirection: "column",
+                gap: "var(--space-3)",
+              }}
+            >
+              <button
+                type="button"
+                className="focus-ring"
+                onClick={handleAddGift}
+                style={{
+                  ...secondaryButton,
+                  background: "var(--color-accent)",
+                  color: "var(--color-surface)",
+                }}
+                aria-label="Add a new gift"
+              >
+                Add gift
+              </button>
+              <button
+                type="button"
+                className="focus-ring"
+                onClick={handleInvite}
+                style={secondaryButton}
+                aria-label="Invite someone"
+              >
+                Invite
+              </button>
+            </div>
+          </section>
+        </div>
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
Implements Space Dashboard landing page shown after creating or joining a space. Adds `/space/:id` route, token-compliant `SpaceHeader`, `GiftListCard`, members list, and quick actions using mock data.

**Checklist**
- [x] Tokens only (spacing/radius/colors/shadows)
- [x] A11y (visible focus ring, keyboardable, ≥44px, AA contrast)
- [x] Route `/space/:id` registered and renders with mock data
- [x] Light motion ≤200ms
- [x] Test plan included

**Test Plan**
- `npm run dev`
- Visit `/space/aurora` → verify header (invite code copy announces via `aria-live="polite"`), gifts summary (empty state visible), members list (≥3 avatars), quick actions.
- Keyboard test: Tab through Copy, View gifts, Add gift, Manage members, Invite; activate with Enter/Space.
- Visit `/space/demo` → verify fallback mock data + empty state.

Closes #<n>

<img width="587" height="910" alt="image" src="https://github.com/user-attachments/assets/9b60d7c7-f2fd-4bf5-ae09-935c79d5244b" />
