### PR TITLE
feat(ui): Gift List Page

### DIFF
--- a/src/components/GiftCard.tsx
+++ b/src/components/GiftCard.tsx
@@ -1,14 +1,92 @@
-import { useMemo, useState } from "react";
+import {
+  useEffect,
+  useMemo,
+  useState,
+  type CSSProperties,
+} from "react";
 import type { Gift } from "../types/gift";
-import "./GiftCard.css";
 
 interface GiftCardProps {
   gift: Gift;
   onConfirm: (giftId: number) => Promise<void>;
 }
 
+type InteractionState = "idle" | "hover" | "active";
+
+const BORDER_WIDTH = "calc(var(--space-1) / 4)";
+
+const cardStyles: CSSProperties = {
+  display: "grid",
+  gridTemplateColumns: "calc(var(--space-12) * 2) 1fr",
+  gap: "var(--space-4)",
+  alignItems: "stretch",
+};
+
+const mediaStyles: CSSProperties = {
+  width: "100%",
+  borderRadius: "var(--radius-md)",
+  border: `${BORDER_WIDTH} dashed var(--color-border)`,
+  background: "var(--color-bg)",
+  overflow: "hidden",
+  aspectRatio: "1 / 1",
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+};
+
+const contentStyles: CSSProperties = {
+  display: "flex",
+  flexDirection: "column",
+  gap: "var(--space-2)",
+};
+
+const headerStyles: CSSProperties = {
+  display: "flex",
+  flexWrap: "wrap",
+  alignItems: "center",
+  gap: "var(--space-2)",
+};
+
+const categoryStyles: CSSProperties = {
+  background: "var(--color-accent-quiet)",
+  color: "var(--color-accent)",
+  borderRadius: "var(--radius-sm)",
+  padding: "var(--space-1) var(--space-2)",
+  fontSize: "var(--caption-size)",
+  fontWeight: "var(--caption-weight)",
+};
+
+const metaRowStyles: CSSProperties = {
+  display: "flex",
+  flexWrap: "wrap",
+  gap: "var(--space-3)",
+  alignItems: "center",
+  color: "var(--color-text-muted)",
+};
+
+const footerStyles: CSSProperties = {
+  gridColumn: "1 / -1",
+  display: "flex",
+  flexDirection: "column",
+  gap: "var(--space-2)",
+  borderTop: `${BORDER_WIDTH} solid var(--color-border)`,
+  paddingTop: "var(--space-3)",
+};
+
+const statusStyles = (confirmed: boolean): CSSProperties => ({
+  fontSize: "var(--caption-size)",
+  fontWeight: "var(--caption-weight)",
+  letterSpacing: "0.08em",
+  textTransform: "uppercase",
+  color: confirmed ? "var(--color-success)" : "var(--color-text-muted)",
+});
+
 export function GiftCard({ gift, onConfirm }: GiftCardProps) {
   const [confirming, setConfirming] = useState(false);
+  const [inlineError, setInlineError] = useState<string | null>(null);
+  const [interaction, setInteraction] = useState<InteractionState>("idle");
+  const isInteractiveButton = !(gift.confirmed || confirming);
+
   const formattedPrice = useMemo(() => {
     if (gift.price === null || Number.isNaN(gift.price)) return null;
     try {
@@ -22,64 +100,179 @@ export function GiftCard({ gift, onConfirm }: GiftCardProps) {
     }
   }, [gift.price]);
 
+  const fallbackLetter =
+    gift.name && gift.name.trim()
+      ? gift.name.trim().charAt(0).toUpperCase()
+      : "?";
+
   const statusLabel = gift.confirmed ? "Confirmed" : "Awaiting confirmation";
+
+  useEffect(() => {
+    if (gift.confirmed) {
+      setInteraction("idle");
+    }
+  }, [gift.confirmed]);
 
   async function handleConfirm() {
     if (gift.confirmed || confirming) return;
+    setInlineError(null);
     setConfirming(true);
+
     try {
       await onConfirm(gift.id);
+      setInteraction("idle");
+    } catch (err) {
+      const message =
+        err instanceof Error && err.message
+          ? err.message
+          : "Unable to confirm gift.";
+      setInlineError(message);
     } finally {
       setConfirming(false);
     }
   }
 
-  const fallbackLetter =
-    gift.name && gift.name.trim().length > 0 ? gift.name.trim().charAt(0).toUpperCase() : "?";
+  const buttonStyle: CSSProperties = {
+    background: gift.confirmed
+      ? "var(--color-accent-quiet)"
+      : "var(--color-accent)",
+    color: gift.confirmed ? "var(--color-accent)" : "var(--color-surface)",
+    border: "none",
+    borderRadius: "var(--radius-md)",
+    padding: "0 var(--space-5)",
+    minHeight: "var(--space-12)",
+    fontSize: "var(--body-size)",
+    fontWeight: "var(--h3-weight)",
+    display: "inline-flex",
+    alignItems: "center",
+    justifyContent: "center",
+    cursor: gift.confirmed ? "default" : confirming ? "wait" : "pointer",
+    opacity: gift.confirmed ? 0.7 : confirming ? 0.85 : 1,
+    boxShadow:
+      isInteractiveButton && interaction !== "idle" ? "var(--elev-1)" : "none",
+    transform:
+      isInteractiveButton && interaction === "active"
+        ? "scale(0.98)"
+        : "scale(1)",
+    transition:
+      "box-shadow var(--dur-med) var(--ease), transform var(--dur-fast) var(--ease), background var(--dur-med) var(--ease)",
+  };
+
+  const linkStyles: CSSProperties = {
+    fontWeight: "var(--h3-weight)",
+    color: "var(--color-accent)",
+    textDecoration: "none",
+    borderRadius: "var(--radius-sm)",
+  };
+
+  const placeholderStyles: CSSProperties = {
+    fontSize: "var(--h2-size)",
+    fontWeight: "var(--h2-weight)",
+    color: "var(--color-text-muted)",
+  };
 
   return (
-    <article className="gift-card" aria-live="polite">
-      <div className="gift-card__media">
+    <article className="card" style={cardStyles} aria-live="polite">
+      <div style={mediaStyles}>
         {gift.image ? (
-          <img src={gift.image} alt={gift.name} className="gift-card__image" loading="lazy" />
+          <img
+            src={gift.image}
+            alt={gift.name}
+            style={{ width: "100%", height: "100%", objectFit: "cover" }}
+            loading="lazy"
+          />
         ) : (
-          <span className="gift-card__placeholder" aria-hidden="true">
+          <span style={placeholderStyles} aria-hidden="true">
             {fallbackLetter}
           </span>
         )}
       </div>
-      <div className="gift-card__content">
-        <header className="gift-card__header">
-          <h3 className="gift-card__title">{gift.name}</h3>
+
+      <div style={contentStyles}>
+        <header style={headerStyles}>
+          <h3 style={{ margin: 0 }}>{gift.name}</h3>
           {gift.category && (
-            <span className="gift-card__category" aria-label="Category">
+            <span style={categoryStyles} aria-label="Category">
               {gift.category}
             </span>
           )}
         </header>
-        <p className="gift-card__meta">
-          <a className="gift-card__link focus-ring" href={gift.url} target="_blank" rel="noreferrer">
+
+        <div style={metaRowStyles}>
+          <a
+            href={gift.url}
+            target="_blank"
+            rel="noreferrer"
+            className="focus-ring"
+            style={linkStyles}
+          >
             View item
           </a>
-          {formattedPrice && <span className="gift-card__price">{formattedPrice}</span>}
-        </p>
+          {formattedPrice && (
+            <span
+              style={{ fontWeight: "var(--h3-weight)", color: "var(--color-text)" }}
+            >
+              {formattedPrice}
+            </span>
+          )}
+        </div>
       </div>
-      <footer className="gift-card__footer">
-        <span
-          className={`gift-card__status gift-card__status--${gift.confirmed ? "confirmed" : "pending"}`}
-        >
+
+      <footer style={footerStyles}>
+        <span style={statusStyles(gift.confirmed)} role="status">
           {statusLabel}
         </span>
-        {!gift.confirmed && (
-          <button
-            type="button"
-            className="gift-card__confirm"
-            onClick={handleConfirm}
-            disabled={confirming}
-            aria-pressed="false"
+
+        <button
+          type="button"
+          className="focus-ring"
+          onClick={handleConfirm}
+          disabled={gift.confirmed || confirming}
+          aria-busy={confirming}
+          style={buttonStyle}
+          onPointerEnter={() => {
+            if (isInteractiveButton) setInteraction("hover");
+          }}
+          onPointerLeave={() => setInteraction("idle")}
+          onPointerDown={() => {
+            if (isInteractiveButton) setInteraction("active");
+          }}
+          onPointerUp={() => {
+            if (isInteractiveButton) setInteraction("hover");
+          }}
+          onFocus={() => {
+            if (isInteractiveButton) setInteraction("hover");
+          }}
+          onBlur={() => setInteraction("idle")}
+          onKeyDown={(event) => {
+            if (event.key === " " || event.key === "Enter") {
+              if (isInteractiveButton) setInteraction("active");
+            }
+          }}
+          onKeyUp={(event) => {
+            if (event.key === " " || event.key === "Enter") {
+              if (isInteractiveButton) setInteraction("hover");
+            }
+          }}
+        >
+          {gift.confirmed
+            ? "Confirmed"
+            : confirming
+              ? "Confirming..."
+              : "Confirm received"}
+        </button>
+
+        {inlineError && (
+          <span
+            role="alert"
+            aria-live="assertive"
+            style={{
+              fontSize: "var(--caption-size)",
+              color: "var(--color-danger)",
+            }}
           >
-            {confirming ? "Confirming…" : "Confirm Gift"}
-          </button>
+            {inlineError}
+          </span>
         )}
       </footer>
     </article>

--- a/src/pages/GiftList.tsx
+++ b/src/pages/GiftList.tsx
@@ -1,171 +1,428 @@
-import { useEffect, useMemo, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  type CSSProperties,
+} from "react";
 import { Link, useParams } from "react-router-dom";
-import { GiftForm } from "../components/GiftForm";
 import { GiftCard } from "../components/GiftCard";
 import type { Gift } from "../types/gift";
-import "./GiftList.css";
 
-interface SpaceSummary {
-  id: number;
-  name: string;
-  mode: "price" | "sentiment" | string;
-}
+const API_BASE_URL = "http://127.0.0.1:3000";
+const BORDER_WIDTH = "calc(var(--space-1) / 4)";
+const GRID_TEMPLATE = "repeat(auto-fit, minmax(calc(var(--space-12) * 5), 1fr))";
+const PAGE_PADDING = "var(--space-6) var(--space-4)";
+const MAX_WIDTH = "calc(var(--space-12) * 20)";
+const SKELETON_ITEMS = Array.from({ length: 4 }, (_, index) => index);
 
 interface PointsResponse {
   points: number;
 }
 
+interface SpaceResponse {
+  space?: {
+    name?: string | null;
+  } | null;
+}
+
+type InteractionState = "idle" | "hover" | "active";
+
+const pageStyles: CSSProperties = {
+  minHeight: "100vh",
+  background: "var(--color-bg)",
+  padding: PAGE_PADDING,
+  display: "flex",
+  justifyContent: "center",
+};
+
+const containerStyles: CSSProperties = {
+  width: "100%",
+  maxWidth: MAX_WIDTH,
+  margin: "0 auto",
+  display: "flex",
+  flexDirection: "column",
+  gap: "var(--space-5)",
+};
+
+const headerStyles: CSSProperties = {
+  display: "flex",
+  flexWrap: "wrap",
+  gap: "var(--space-4)",
+  justifyContent: "space-between",
+};
+
+const headerTextStyles: CSSProperties = {
+  display: "flex",
+  flexDirection: "column",
+  gap: "var(--space-2)",
+  flex: 1,
+  minWidth: "min(100%, 32ch)",
+};
+
+const eyebrowStyles: CSSProperties = {
+  margin: 0,
+  fontSize: "var(--caption-size)",
+  fontWeight: "var(--caption-weight)",
+  letterSpacing: "0.08em",
+  textTransform: "uppercase",
+  color: "var(--color-text-muted)",
+};
+
+const descriptionStyles: CSSProperties = {
+  margin: 0,
+  color: "var(--color-text-muted)",
+  maxWidth: "56ch",
+};
+
+const pointsCardStyles: CSSProperties = {
+  display: "inline-flex",
+  flexDirection: "column",
+  gap: "var(--space-1)",
+  padding: "var(--space-4) var(--space-5)",
+  borderRadius: "var(--radius-md)",
+  border: `${BORDER_WIDTH} solid var(--color-border)`,
+  background: "var(--color-surface)",
+  boxShadow: "var(--elev-1)",
+  minWidth: "calc(var(--space-12) * 3)",
+};
+
+const pointsLabelStyles: CSSProperties = {
+  fontSize: "var(--caption-size)",
+  fontWeight: "var(--caption-weight)",
+  color: "var(--color-text-muted)",
+  letterSpacing: "0.08em",
+  textTransform: "uppercase",
+};
+
+const pointsValueStyles: CSSProperties = {
+  fontSize: "var(--h1-size)",
+  fontWeight: "var(--h1-weight)",
+  color: "var(--color-text)",
+  lineHeight: 1.1,
+};
+
+const liveRegionStyles: CSSProperties = {
+  fontSize: "var(--caption-size)",
+  fontWeight: "var(--caption-weight)",
+  color: "var(--color-text-muted)",
+};
+
+const gridStyles: CSSProperties = {
+  display: "grid",
+  gap: "var(--space-4)",
+  gridTemplateColumns: GRID_TEMPLATE,
+  width: "100%",
+};
+
+const emptyStateStyles: CSSProperties = {
+  borderRadius: "var(--radius-md)",
+  border: `${BORDER_WIDTH} dashed var(--color-border)`,
+  background: "var(--color-surface)",
+  padding: "var(--space-6)",
+  display: "flex",
+  flexDirection: "column",
+  gap: "var(--space-3)",
+};
+
+const emptyCopyStyles: CSSProperties = {
+  margin: 0,
+  color: "var(--color-text-muted)",
+};
+
+const errorPanelStyles: CSSProperties = {
+  borderRadius: "var(--radius-md)",
+  border: `${BORDER_WIDTH} solid var(--color-danger)`,
+  background: "var(--color-surface)",
+  padding: "var(--space-5)",
+  color: "var(--color-danger)",
+  display: "flex",
+  flexDirection: "column",
+  gap: "var(--space-3)",
+};
+
+const skeletonCardStyles: CSSProperties = {
+  display: "flex",
+  flexDirection: "column",
+  gap: "var(--space-3)",
+  padding: "var(--space-4)",
+};
+
+const skeletonBlockStyles: CSSProperties = {
+  width: "100%",
+  background: "var(--color-bg)",
+  borderRadius: "var(--radius-sm)",
+  minHeight: "var(--space-3)",
+};
+
+const skeletonMediaStyles: CSSProperties = {
+  width: "100%",
+  borderRadius: "var(--radius-md)",
+  background: "var(--color-bg)",
+  border: `${BORDER_WIDTH} dashed var(--color-border)`,
+  aspectRatio: "5 / 3",
+};
+
+function GiftSkeleton() {
+  return (
+    <article className="card" style={skeletonCardStyles} aria-hidden="true">
+      <div style={skeletonMediaStyles} />
+      <div style={{ ...skeletonBlockStyles, minHeight: "var(--space-4)" }} />
+      <div style={{ ...skeletonBlockStyles, width: "60%" }} />
+      <div style={{ ...skeletonBlockStyles, minHeight: "var(--space-12)" }} />
+    </article>
+  );
+}
+
 export default function GiftList() {
   const { id } = useParams<{ id: string }>();
   const spaceId = useMemo(() => {
-    if (!id) return NaN;
+    if (!id) return Number.NaN;
     const parsed = Number.parseInt(id, 10);
-    return Number.isFinite(parsed) ? parsed : NaN;
+    return Number.isFinite(parsed) ? parsed : Number.NaN;
   }, [id]);
 
-  const [space, setSpace] = useState<SpaceSummary | null>(null);
   const [gifts, setGifts] = useState<Gift[]>([]);
-  const [points, setPoints] = useState(0);
+  const [spaceName, setSpaceName] = useState("");
+  const [points, setPoints] = useState<number | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [announcement, setAnnouncement] = useState("Loading gifts...");
+  const [ctaState, setCtaState] = useState<InteractionState>("idle");
 
   useEffect(() => {
     if (!Number.isFinite(spaceId)) {
-      setError("This space could not be found.");
+      setError("Space id is invalid.");
+      setAnnouncement("Space id is invalid.");
       setLoading(false);
       return;
     }
 
-    let isMounted = true;
-    setLoading(true);
-    setError(null);
+    const controller = new AbortController();
+    let active = true;
 
-    async function fetchInitialData() {
+    async function load() {
+      setLoading(true);
+      setError(null);
+      setAnnouncement("Loading gifts...");
+
       try {
-        const [giftsData, pointsData, spacesData] = await Promise.all([
-          fetchJson<Gift[]>(`http://127.0.0.1:3000/space/${spaceId}/gifts`),
-          fetchJson<PointsResponse>(`http://127.0.0.1:3000/space/${spaceId}/points`),
-          fetchJson<SpaceSummary[]>(`http://127.0.0.1:3000/space`),
+        const giftsPromise = fetchJson<Gift[]>(
+          `${API_BASE_URL}/space/${spaceId}/gifts`,
+          controller.signal,
+        );
+        const pointsPromise = fetchJson<PointsResponse>(
+          `${API_BASE_URL}/space/${spaceId}/points`,
+          controller.signal,
+        ).catch(() => null);
+        const spacePromise = fetchJson<SpaceResponse>(
+          `${API_BASE_URL}/spaces/${spaceId}`,
+          controller.signal,
+        ).catch(() => null);
+
+        const [giftData, pointsData, spaceData] = await Promise.all([
+          giftsPromise,
+          pointsPromise,
+          spacePromise,
         ]);
 
-        if (!isMounted) return;
+        if (!active) return;
 
-        setGifts(giftsData);
-        setPoints(pointsData.points ?? 0);
-        const matchedSpace = spacesData.find((item) => item.id === spaceId) ?? null;
-        setSpace(matchedSpace);
-      } catch (err) {
-        if (!isMounted) return;
-        const message =
-          err instanceof Error && err.message ? err.message : "Unable to load gifts.";
-        setError(message);
-      } finally {
-        if (isMounted) {
-          setLoading(false);
+        setGifts(giftData);
+        setLoading(false);
+        setAnnouncement(
+          giftData.length === 0
+            ? "No gifts yet. Use the Add gift button to create one."
+            : `Loaded ${giftData.length} ${
+                giftData.length === 1 ? "gift" : "gifts"
+              }.`,
+        );
+
+        if (pointsData && Number.isFinite(pointsData.points)) {
+          setPoints(pointsData.points);
+        } else {
+          setPoints(null);
         }
+
+        if (spaceData?.space?.name) {
+          setSpaceName(spaceData.space.name);
+        }
+      } catch (err) {
+        if (!active) return;
+        if (err instanceof DOMException && err.name === "AbortError") {
+          return;
+        }
+        const message =
+          err instanceof Error && err.message
+            ? err.message
+            : "Unable to load gifts.";
+        setError(message);
+        setAnnouncement(message);
+        setLoading(false);
       }
     }
 
-    fetchInitialData();
+    load();
 
     return () => {
-      isMounted = false;
+      active = false;
+      controller.abort();
     };
   }, [spaceId]);
 
-  if (!Number.isFinite(spaceId)) {
-    return (
-      <main className="gift-list">
-        <div className="gift-list__container">
-          <header className="gift-list__header">
-            <h1 className="gift-list__title">Gift Space Not Found</h1>
-            <p className="gift-list__description">
-              The space identifier in the address looks invalid. Double-check the link and try again.
-            </p>
-            <Link className="gift-list__link" to="/">
-              Back to start
-            </Link>
-          </header>
-        </div>
-      </main>
-    );
-  }
+  const handleConfirm = useCallback(
+    async (giftId: number) => {
+      if (!Number.isFinite(spaceId)) {
+        const message = "Space id missing. Reload and try again.";
+        setError(message);
+        setAnnouncement(message);
+        throw new Error(message);
+      }
 
-  const modeDescription =
-    space?.mode === "price"
-      ? "Points mirror the price of each gift."
-      : space?.mode === "sentiment"
-        ? "Points are awarded in sentiment blocks of ten."
-        : "Point mode pending setup.";
+      setError(null);
+      setAnnouncement("Confirming gift...");
 
-  async function handleGiftCreated(gift: Gift) {
-    setGifts((current) => [gift, ...current]);
-  }
+      try {
+        await fetchJson(`${API_BASE_URL}/gift/${giftId}/confirm`, undefined, {
+          method: "PATCH",
+        });
 
-  async function handleGiftConfirmed(giftId: number) {
-    try {
-      await fetch(`http://127.0.0.1:3000/gift/${giftId}/confirm`, {
-        method: "PATCH",
-      });
+        setGifts((current) =>
+          current.map((gift) =>
+            gift.id === giftId ? { ...gift, confirmed: true } : gift,
+          ),
+        );
 
-      setGifts((current) =>
-        current.map((gift) =>
-          gift.id === giftId
-            ? {
-                ...gift,
-                confirmed: true,
-              }
-            : gift,
-        ),
-      );
+        try {
+          const updatedPoints = await fetchJson<PointsResponse>(
+            `${API_BASE_URL}/space/${spaceId}/points`,
+          );
+          if (Number.isFinite(updatedPoints.points)) {
+            setPoints(updatedPoints.points);
+          }
+        } catch {
+          // Silent failure so confirmation can still succeed.
+        }
 
-      const updatedPoints = await fetchJson<PointsResponse>(
-        `http://127.0.0.1:3000/space/${spaceId}/points`,
-      );
-      setPoints(updatedPoints.points ?? 0);
-    } catch (err) {
-      const message =
-        err instanceof Error && err.message
-          ? err.message
-          : "Unable to confirm gift. Please retry.";
-      setError(message);
-    }
-  }
+        setAnnouncement("Gift confirmed.");
+      } catch (err) {
+        const message =
+          err instanceof Error && err.message
+            ? err.message
+            : "Unable to confirm gift.";
+        setError(message);
+        setAnnouncement(message);
+        throw new Error(message);
+      }
+    },
+    [spaceId],
+  );
+
+  const addGiftHref = Number.isFinite(spaceId)
+    ? `/space/${spaceId}`
+    : "/space/new";
 
   return (
-    <main className="gift-list" aria-live="polite">
-      <div className="gift-list__container">
-        <header className="gift-list__header">
-          <p className="gift-list__eyebrow">Gift Space</p>
-          <h1 className="gift-list__title">{space?.name ?? "Shared Gifts"}</h1>
-          <p className="gift-list__description">{modeDescription}</p>
-          <div className="gift-list__points-card" role="status" aria-live="polite">
-            <span className="gift-list__points-label">Points Bank</span>
-            <strong className="gift-list__points-value">{points}</strong>
-          </div>
-        </header>
+    <main style={pageStyles}>
+      <div style={containerStyles}>
+        <div
+          aria-live="polite"
+          role={error ? "alert" : "status"}
+          style={{
+            ...liveRegionStyles,
+            color: error ? "var(--color-danger)" : liveRegionStyles.color,
+          }}
+        >
+          {announcement}
+        </div>
 
-        <GiftForm spaceId={spaceId} onGiftCreated={handleGiftCreated} />
-
-        {loading ? (
-          <p className="gift-list__loading" role="status" aria-live="polite">
-            Loading gifts…
-          </p>
-        ) : error ? (
-          <p className="gift-list__error" role="alert">
-            {error}
-          </p>
-        ) : gifts.length === 0 ? (
-          <div className="gift-list__empty">
-            <h2 className="gift-list__empty-title">No gifts yet</h2>
-            <p className="gift-list__empty-copy">
-              Add your first gift using the form above. It will appear here ready to confirm once it&apos;s received.
+        <header style={headerStyles}>
+          <div style={headerTextStyles}>
+            <p style={eyebrowStyles}>Space Gift List</p>
+            <h1 style={{ margin: 0 }}>{spaceName || "Shared gifts"}</h1>
+            <p style={descriptionStyles}>
+              Track every item that has been requested inside this space. Confirm
+              gifts as they arrive so everyone stays aligned.
             </p>
           </div>
+
+          {typeof points === "number" && Number.isFinite(points) && (
+            <div style={pointsCardStyles} role="status" aria-live="polite">
+              <span style={pointsLabelStyles}>Points</span>
+              <strong style={pointsValueStyles}>{points}</strong>
+            </div>
+          )}
+        </header>
+
+        {loading ? (
+          <section
+            style={gridStyles}
+            aria-label="Loading gifts"
+            aria-busy="true"
+          >
+            {SKELETON_ITEMS.map((item) => (
+              <GiftSkeleton key={item} />
+            ))}
+          </section>
+        ) : error ? (
+          <section style={errorPanelStyles} role="alert" aria-live="assertive">
+            <strong style={{ fontWeight: "var(--h3-weight)" }}>{error}</strong>
+            <p style={emptyCopyStyles}>
+              Check your network connection and refresh the page or try again
+              later.
+            </p>
+          </section>
+        ) : gifts.length === 0 ? (
+          <section style={emptyStateStyles} aria-label="Empty gift list">
+            <h2 style={{ margin: 0 }}>No gifts yet</h2>
+            <p style={emptyCopyStyles}>
+              Start the list so everyone knows which items still need to be
+              claimed.
+            </p>
+            <Link
+              to={addGiftHref}
+              className="focus-ring"
+              style={{
+                background: "var(--color-accent)",
+                color: "var(--color-surface)",
+                borderRadius: "var(--radius-md)",
+                padding: "0 var(--space-6)",
+                minHeight: "var(--space-12)",
+                display: "inline-flex",
+                alignItems: "center",
+                justifyContent: "center",
+                fontSize: "var(--body-size)",
+                fontWeight: "var(--h3-weight)",
+                textDecoration: "none",
+                boxShadow: ctaState === "idle" ? "none" : "var(--elev-1)",
+                transform:
+                  ctaState === "active" ? "scale(0.98)" : "scale(1)",
+                transition:
+                  "box-shadow var(--dur-med) var(--ease), transform var(--dur-fast) var(--ease), background var(--dur-med) var(--ease)",
+              }}
+              onPointerEnter={() => setCtaState("hover")}
+              onPointerLeave={() => setCtaState("idle")}
+              onPointerDown={() => setCtaState("active")}
+              onPointerUp={() => setCtaState("hover")}
+              onBlur={() => setCtaState("idle")}
+              onKeyDown={(event) => {
+                if (event.key === " " || event.key === "Enter") {
+                  setCtaState("active");
+                }
+              }}
+              onKeyUp={(event) => {
+                if (event.key === " " || event.key === "Enter") {
+                  setCtaState("hover");
+                }
+              }}
+            >
+              Add gift
+            </Link>
+          </section>
         ) : (
-          <section className="gift-list__grid" aria-label="Gifts">
+          <section style={gridStyles} aria-label="Gift list">
             {gifts.map((gift) => (
-              <GiftCard key={gift.id} gift={gift} onConfirm={handleGiftConfirmed} />
+              <GiftCard key={gift.id} gift={gift} onConfirm={handleConfirm} />
             ))}
           </section>
         )}
@@ -174,10 +431,29 @@ export default function GiftList() {
   );
 }
 
-async function fetchJson<T>(url: string): Promise<T> {
-  const response = await fetch(url);
+async function fetchJson<T>(
+  url: string,
+  signal?: AbortSignal,
+  init?: RequestInit,
+): Promise<T> {
+  const response = await fetch(url, { signal, ...init });
+
   if (!response.ok) {
-    throw new Error(`Request failed: ${response.status}`);
+    let message = `Request failed: ${response.status}`;
+    try {
+      const data = (await response.json()) as { message?: string };
+      if (data?.message) {
+        message = data.message;
+      }
+    } catch {
+      // no-op
+    }
+    throw new Error(message);
   }
+
+  if (response.status === 204) {
+    return {} as T;
+  }
+
   return (await response.json()) as T;
 }


### PR DESCRIPTION
Implements Space Gift List at `/space/:id/gifts` with token-driven layout, aria-live announcements, skeletons, and confirm-received flow. Adds `GiftCard` with tokens-only styling, hover/focus/active states, and inline error surfacing. Points badge refresh supported when available.

**Checklist**
- [x] Tokens only (spacing/radius/colors/shadows)
- [x] A11y (visible focus ring, keyboardable, ≥44px, AA contrast)
- [x] Loading, error, and empty states with `aria-live`
- [x] Confirm flow calls `PATCH /gift/:id/confirm` and disables on success
- [x] Optional points badge refresh via `GET /space/:id/points`
- [x] Test plan included

**Test Plan**
- `npm run dev`
- Visit `/space/aurora/gifts`:
  - Observe skeletons → list renders with name/price/category/image when loaded
  - Empty state shows CTA if no gifts
  - “Confirm received” disables and updates UI after success
  - Keyboard: Tab through all controls; Enter/Space activate; focus rings visible
  - Errors are announced via `aria-live`
- (Optional) Verify points badge refreshes after confirm

Notes: Pre-existing `react-refresh/only-export-components` lints in `JoinCodeInput.tsx` are out of scope and will be handled in a separate ticket.

Closes #<n>