### PR TITLE
chore(db): seed demo spaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,73 +1,47 @@
-# React + TypeScript + Vite
+# GiftLink
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+GiftLink pairs a lightweight Fastify backend with a Vite + React client to make sharing gift ideas feel effortless.
 
-Currently, two official plugins are available:
+## Getting Started
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) (or [oxc](https://oxc.rs) when used in [rolldown-vite](https://vite.dev/guide/rolldown)) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+1. Install dependencies:
+   ```bash
+   npm install
+   npm --prefix backend install
+   ```
+   The backend ships with a default SQLite path; copy `backend/.env.example` to `backend/.env` if you need a different location.
+2. Sync the database schema (creates `backend/prisma/dev.db` when needed):
+   ```bash
+   (cd backend && npx prisma db push)
+   ```
+3. Start the development server(s) as needed.
 
-## React Compiler
+## Database Seeding
 
-The React Compiler is not enabled on this template because of its impact on dev & build performances. To add it, see [this documentation](https://react.dev/learn/react-compiler/installation).
+Seed data helps you preview the Space dashboard and join flow without manual setup.
 
-## Expanding the ESLint configuration
+1. Populate demo data (this also ensures the schema is pushed):
+   ```bash
+   npm run db:seed
+   ```
+2. You will see calm confirmation logs similar to:
+   ```
+   🌱 Preparing demo spaces for GiftLink...
+   ✨ Demo spaces ready. Join codes:
+   • Alpha Space → "alpha-space"
+   • Beta Space → "beta-space"
+   🤝 Re-run this seed anytime for a fresh-yet-familiar test bed.
+   ```
+3. Verify the records if desired:
+   ```bash
+   (cd backend && npx prisma studio)
+   ```
+   or run a quick SQL check:
+   ```bash
+   (cd backend && npx prisma db execute --stdin <<'SQL'
+   SELECT joinCode FROM Space;
+   SQL
+   )
+   ```
 
-If you are developing a production application, we recommend updating the configuration to enable type-aware lint rules:
-
-```js
-export default defineConfig([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
-
-      // Remove tseslint.configs.recommended and replace with this
-      tseslint.configs.recommendedTypeChecked,
-      // Alternatively, use this for stricter rules
-      tseslint.configs.strictTypeChecked,
-      // Optionally, add this for stylistic rules
-      tseslint.configs.stylisticTypeChecked,
-
-      // Other configs...
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
-```
-
-You can also install [eslint-plugin-react-x](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x) and [eslint-plugin-react-dom](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-dom) for React-specific lint rules:
-
-```js
-// eslint.config.js
-import reactX from 'eslint-plugin-react-x'
-import reactDom from 'eslint-plugin-react-dom'
-
-export default defineConfig([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
-      // Enable lint rules for React
-      reactX.configs['recommended-typescript'],
-      // Enable lint rules for React DOM
-      reactDom.configs.recommended,
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
-```
+The seed is idempotent, so you can re-run it whenever you want to reset join codes for manual testing.

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,2 @@
+# SQLite database path for local development
+DATABASE_URL="file:./prisma/dev.db"

--- a/backend/package.json
+++ b/backend/package.json
@@ -5,7 +5,8 @@
   "main": "server.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "node server.js"
+    "start": "node server.js",
+    "db:seed": "node scripts/run-prisma-with-db-url.js db push && node scripts/run-prisma-with-db-url.js db seed"
   },
   "keywords": [],
   "author": "",

--- a/backend/prisma.config.ts
+++ b/backend/prisma.config.ts
@@ -1,15 +1,22 @@
 // ✅ this line loads backend/.env for Prisma v6
 import "dotenv/config";
 
-import { defineConfig, env } from "prisma/config";
+import { defineConfig } from "prisma/config";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const configDir = path.dirname(fileURLToPath(import.meta.url));
+const fallbackDatabaseUrl = pathToFileURL(path.join(configDir, "prisma", "dev.db")).toString();
+const databaseUrl = process.env.DATABASE_URL ?? fallbackDatabaseUrl;
 
 export default defineConfig({
   schema: "prisma/schema.prisma",
   migrations: {
     path: "prisma/migrations",
+    seed: "node prisma/seed.js",
   },
   engine: "classic",
   datasource: {
-    url: env("DATABASE_URL"),
+    url: databaseUrl,
   },
 });

--- a/backend/prisma/seed.js
+++ b/backend/prisma/seed.js
@@ -1,0 +1,67 @@
+import pkg from "@prisma/client";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const { PrismaClient } = pkg;
+const seedDir = path.dirname(fileURLToPath(import.meta.url));
+const fallbackDatabaseUrl = pathToFileURL(path.join(seedDir, "dev.db")).toString();
+const databaseUrl = process.env.DATABASE_URL ?? fallbackDatabaseUrl;
+process.env.DATABASE_URL = databaseUrl;
+const prisma = new PrismaClient();
+
+const demoSpaces = [
+  {
+    name: "Alpha Space",
+    description: "A calm sandbox to explore the dashboard.",
+    inviteCode: "alpha-invite",
+    joinCode: "alpha-space",
+    mode: "demo",
+  },
+  {
+    name: "Beta Space",
+    description: "A second space for testing the join flow.",
+    inviteCode: "beta-invite",
+    joinCode: "beta-space",
+    mode: "demo",
+  },
+];
+
+async function main() {
+  console.log("🌱 Preparing demo spaces for GiftLink...");
+
+  const confirmedSpaces = [];
+
+  for (const spaceData of demoSpaces) {
+    const space = await prisma.space.upsert({
+      where: { joinCode: spaceData.joinCode },
+      update: {
+        name: spaceData.name,
+        description: spaceData.description,
+        inviteCode: spaceData.inviteCode,
+        mode: spaceData.mode,
+      },
+      create: {
+        ...spaceData,
+      },
+    });
+
+    confirmedSpaces.push(space);
+  }
+
+  console.log("✨ Demo spaces ready. Join codes:");
+  for (const space of confirmedSpaces) {
+    console.log(`• ${space.name} → "${space.joinCode}"`);
+  }
+
+  console.log("🤝 Re-run this seed anytime for a fresh-yet-familiar test bed.");
+}
+
+main()
+  .catch((error) => {
+    console.error("Seed did not complete. Details:");
+    console.error(error);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/backend/scripts/run-prisma-with-db-url.js
+++ b/backend/scripts/run-prisma-with-db-url.js
@@ -1,0 +1,36 @@
+#!/usr/bin/env node
+import { spawn } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const scriptsDir = path.dirname(fileURLToPath(import.meta.url));
+const backendDir = path.resolve(scriptsDir, "..");
+const prismaBinary = path.join(
+  backendDir,
+  "node_modules",
+  ".bin",
+  process.platform === "win32" ? "prisma.cmd" : "prisma"
+);
+const dbFile = path.join(backendDir, "prisma", "dev.db");
+const databaseUrl = process.env.DATABASE_URL ?? pathToFileURL(dbFile).toString();
+const args = process.argv.slice(2);
+
+const child = spawn(prismaBinary, args, {
+  cwd: backendDir,
+  stdio: "inherit",
+  env: {
+    ...process.env,
+    DATABASE_URL: databaseUrl,
+  },
+});
+
+child.on("exit", (code, signal) => {
+  if (typeof code === "number") {
+    process.exit(code);
+  }
+  if (signal) {
+    process.kill(process.pid, signal);
+  } else {
+    process.exit(1);
+  }
+});

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "db:seed": "cd backend && npm run db:seed"
   },
   "dependencies": {
     "axios": "^1.12.2",


### PR DESCRIPTION
## Summary
- add a Prisma seed script that upserts two demo spaces with calm confirmation logs
- introduce a helper runner so Prisma CLI commands pick up the default SQLite database and wire the db:seed npm scripts
- refresh the README with seeding instructions and provide an .env example for overriding the database path

## Testing
- npm run db:seed


------
https://chatgpt.com/codex/tasks/task_b_68fd4b74ae0c832ba7a68d03f096777c