### PR TITLE
feat(core): implement wishlist and gift lifecycle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@ dist
 dist-ssr
 *.local
 
+# Test databases
+backend/prisma/test.db
+
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,30 @@
+# GiftLink Backend
+
+## Wishlist & Gift Lifecycle API
+
+### Create a wishlist item
+`POST /wishlist`
+
+Creates a wishlist item for a space. When a `url` is provided the backend attempts to ingest Open Graph metadata but manual fields always win. Returns the created item with its associated gift record.
+
+### List wishlist items
+`GET /wishlist?spaceId=<id>`
+
+Supports optional filters: `category`, `priority`, `archived` (default `false`), `priceMin`, and `priceMax` (all in cents).
+
+### Update a wishlist item
+`PATCH /wishlist/:id`
+
+Allows updating `notes`, `priority`, and `archived` status.
+
+### Gift lifecycle
+
+* `POST /gift/:id/reserve` – reserve a gift for a giver.
+* `POST /gift/:id/purchase` – lock the price-indexed point value.
+* `POST /gift/:id/deliver` – mark the gift as delivered.
+* `POST /gift/:id/receive` – complete the lifecycle and receive the calculated points in the response.
+
+### Gift listings
+`GET /space/:id/gifts`
+
+Returns gifts for a space with lightweight wishlist item context.

--- a/backend/lib/giftPoints.js
+++ b/backend/lib/giftPoints.js
@@ -1,0 +1,34 @@
+export const POINT_MODES = {
+  PRICE: "PRICE",
+  SENTIMENT: "SENTIMENT",
+};
+
+export function roundPriceToPoints(priceCents) {
+  if (typeof priceCents !== "number" || Number.isNaN(priceCents)) {
+    return 0;
+  }
+  const normalized = Math.round(priceCents / 100);
+  if (!Number.isFinite(normalized) || normalized < 0) {
+    return 0;
+  }
+  return normalized;
+}
+
+export function resolvePointsForGift(spaceMode, gift, wishlistItem) {
+  const normalizedMode = typeof spaceMode === "string" ? spaceMode.toLowerCase() : "price";
+  if (normalizedMode === "sentiment") {
+    const sentiment = gift?.sentimentPoints;
+    if (typeof sentiment !== "number" || !Number.isFinite(sentiment) || sentiment < 0) {
+      return { points: 0, mode: POINT_MODES.SENTIMENT };
+    }
+    return { points: Math.trunc(sentiment), mode: POINT_MODES.SENTIMENT };
+  }
+
+  const locked = gift?.pricePointsLocked;
+  if (typeof locked === "number" && Number.isFinite(locked)) {
+    return { points: Math.max(0, Math.trunc(locked)), mode: POINT_MODES.PRICE };
+  }
+
+  const fallback = roundPriceToPoints(wishlistItem?.priceCents ?? null);
+  return { points: fallback, mode: POINT_MODES.PRICE };
+}

--- a/backend/lib/urlMetadata.js
+++ b/backend/lib/urlMetadata.js
@@ -1,0 +1,168 @@
+const HTML_CONTENT_TYPES = ["text/html", "application/xhtml+xml"];
+
+function normalizePriceCandidate(candidate) {
+  if (typeof candidate !== "string") {
+    return null;
+  }
+
+  const cleaned = candidate
+    .replace(/&amp;/gi, "&")
+    .replace(/\s+/g, " ")
+    .trim();
+
+  if (!cleaned) {
+    return null;
+  }
+
+  const match = cleaned.match(/([-+]?[0-9]*[.,]?[0-9]+)/);
+  if (!match) {
+    return null;
+  }
+
+  const numeric = match[1].replace(/,/g, "");
+  const parsed = Number.parseFloat(numeric);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    return null;
+  }
+
+  return Math.round(parsed * 100);
+}
+
+function extractMetaContent(html, names) {
+  const pattern = new RegExp(
+    `<meta[^>]+(?:name|property)=["'](${names.join("|")})["'][^>]*content=["']([^"']+)["'][^>]*>`,
+    "i",
+  );
+  const match = html.match(pattern);
+  return match ? match[2].trim() : null;
+}
+
+function extractTitle(html) {
+  const title = extractMetaContent(html, ["og:title", "twitter:title", "title"]);
+  if (title) {
+    return title;
+  }
+  const match = html.match(/<title>([^<]+)<\/title>/i);
+  return match ? match[1].trim() : null;
+}
+
+function extractImage(html) {
+  return (
+    extractMetaContent(html, ["og:image", "twitter:image", "og:image:url"]) ||
+    extractMetaContent(html, ["image", "og:image:secure_url"]) ||
+    null
+  );
+}
+
+function extractPrice(html) {
+  const priceMeta =
+    extractMetaContent(html, ["product:price:amount", "og:price:amount", "price", "twitter:data1"]) ||
+    null;
+
+  if (priceMeta) {
+    const cents = normalizePriceCandidate(priceMeta);
+    if (cents !== null) {
+      return cents;
+    }
+  }
+
+  const match = html.match(/\b(?:USD|\$)\s*([0-9]+(?:\.[0-9]{1,2})?)/i);
+  if (match) {
+    const cents = normalizePriceCandidate(match[1]);
+    if (cents !== null) {
+      return cents;
+    }
+  }
+
+  return null;
+}
+
+function shouldAttemptFetch(url) {
+  try {
+    const parsed = new URL(url);
+    return parsed.protocol === "http:" || parsed.protocol === "https:";
+  } catch (error) {
+    return false;
+  }
+}
+
+async function readLimitedBody(response, maxBytes) {
+  const reader = response.body?.getReader();
+  if (!reader) {
+    const text = await response.text();
+    return text.slice(0, maxBytes);
+  }
+
+  let received = 0;
+  const chunks = [];
+
+  while (received < maxBytes) {
+    const { value, done } = await reader.read();
+    if (done) {
+      break;
+    }
+    if (value) {
+      const chunk = value.length + received > maxBytes ? value.slice(0, maxBytes - received) : value;
+      chunks.push(chunk);
+      received += chunk.length;
+      if (received >= maxBytes) {
+        break;
+      }
+    }
+  }
+
+  return Buffer.concat(chunks).toString("utf-8");
+}
+
+export async function fetchUrlMetadata(url, { timeoutMs = 3500, maxBytes = 150_000 } = {}) {
+  if (!shouldAttemptFetch(url)) {
+    return { title: null, image: null, priceCents: null };
+  }
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const response = await fetch(url, {
+      method: "GET",
+      redirect: "follow",
+      signal: controller.signal,
+      headers: {
+        "User-Agent": "GiftLinkBot/1.0 (+https://giftlink.example)",
+        Accept: HTML_CONTENT_TYPES.join(","),
+      },
+    });
+
+    if (!response.ok) {
+      return { title: null, image: null, priceCents: null };
+    }
+
+    const contentType = response.headers.get("content-type") || "";
+    if (!HTML_CONTENT_TYPES.some((type) => contentType.includes(type))) {
+      return { title: null, image: null, priceCents: null };
+    }
+
+    const snippet = await readLimitedBody(response, maxBytes);
+
+    return {
+      title: extractTitle(snippet),
+      image: extractImage(snippet),
+      priceCents: extractPrice(snippet),
+    };
+  } catch (error) {
+    if (error?.name === "AbortError") {
+      return { title: null, image: null, priceCents: null };
+    }
+    return { title: null, image: null, priceCents: null };
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+export function mergeMetadataWithManualFields(metadata, manual = {}) {
+  return {
+    title: manual.title ?? metadata.title ?? null,
+    image: manual.image ?? metadata.image ?? null,
+    priceCents: manual.priceCents ?? metadata.priceCents ?? null,
+  };
+}

--- a/backend/package.json
+++ b/backend/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "main": "server.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "NODE_ENV=test node --test",
     "start": "node server.js"
   },
   "keywords": [],

--- a/backend/prisma/migrations/20251025225816_wishlist_gift_lifecycle/migration.sql
+++ b/backend/prisma/migrations/20251025225816_wishlist_gift_lifecycle/migration.sql
@@ -1,0 +1,56 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `category` on the `Gift` table. All the data in the column will be lost.
+  - You are about to drop the column `confirmed` on the `Gift` table. All the data in the column will be lost.
+  - You are about to drop the column `image` on the `Gift` table. All the data in the column will be lost.
+  - You are about to drop the column `name` on the `Gift` table. All the data in the column will be lost.
+  - You are about to drop the column `price` on the `Gift` table. All the data in the column will be lost.
+  - You are about to drop the column `spaceId` on the `Gift` table. All the data in the column will be lost.
+  - You are about to drop the column `url` on the `Gift` table. All the data in the column will be lost.
+  - Added the required column `wishlistItemId` to the `Gift` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- CreateTable
+CREATE TABLE "WishlistItem" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "spaceId" INTEGER NOT NULL,
+    "title" TEXT NOT NULL,
+    "url" TEXT,
+    "image" TEXT,
+    "priceCents" INTEGER,
+    "category" TEXT,
+    "notes" TEXT,
+    "priority" TEXT NOT NULL DEFAULT 'MEDIUM',
+    "archived" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "WishlistItem_spaceId_fkey" FOREIGN KEY ("spaceId") REFERENCES "Space" ("id") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_Gift" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "wishlistItemId" INTEGER NOT NULL,
+    "giverId" INTEGER,
+    "status" TEXT NOT NULL DEFAULT 'PENDING',
+    "sentimentPoints" INTEGER,
+    "pricePointsLocked" INTEGER,
+    "reservedAt" DATETIME,
+    "purchasedAt" DATETIME,
+    "deliveredAt" DATETIME,
+    "receivedAt" DATETIME,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "Gift_wishlistItemId_fkey" FOREIGN KEY ("wishlistItemId") REFERENCES "WishlistItem" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT "Gift_giverId_fkey" FOREIGN KEY ("giverId") REFERENCES "User" ("id") ON DELETE SET NULL ON UPDATE CASCADE
+);
+INSERT INTO "new_Gift" ("createdAt", "id", "updatedAt") SELECT "createdAt", "id", "updatedAt" FROM "Gift";
+DROP TABLE "Gift";
+ALTER TABLE "new_Gift" RENAME TO "Gift";
+CREATE UNIQUE INDEX "Gift_wishlistItemId_key" ON "Gift"("wishlistItemId");
+CREATE INDEX "Gift_wishlistItemId_idx" ON "Gift"("wishlistItemId");
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -12,33 +12,70 @@ model User {
   name      String
   email     String   @unique
   createdAt DateTime @default(now())
+  gifts     Gift[]
 }
 
 model Space {
-  id          Int      @id @default(autoincrement())
-  name        String
-  description String?
-  inviteCode  String   @unique
-  joinCode    String   @unique
-  mode        String
-  points      Int      @default(0)
-  createdAt   DateTime @default(now())
-  updatedAt   DateTime @updatedAt
-  gifts       Gift[]
+  id            Int            @id @default(autoincrement())
+  name          String
+  description   String?
+  inviteCode    String         @unique
+  joinCode      String         @unique
+  mode          String
+  points        Int            @default(0)
+  createdAt     DateTime       @default(now())
+  updatedAt     DateTime       @updatedAt
+  wishlistItems WishlistItem[]
 }
 
-model Gift {
+model WishlistItem {
   id         Int       @id @default(autoincrement())
-  name       String
-  url        String
-  image      String?
-  price      Float?
-  category   String?
-  confirmed  Boolean   @default(false)
   spaceId    Int
+  title      String
+  url        String?
+  image      String?
+  priceCents Int?
+  category   String?
+  notes      String?
+  priority   Priority  @default(MEDIUM)
+  archived   Boolean   @default(false)
   createdAt  DateTime  @default(now())
   updatedAt  DateTime  @updatedAt
   space      Space     @relation(fields: [spaceId], references: [id])
+  gift       Gift?
+}
+
+model Gift {
+  id                Int         @id @default(autoincrement())
+  wishlistItemId    Int         @unique
+  giverId           Int?
+  status            GiftStatus  @default(PENDING)
+  sentimentPoints   Int?
+  pricePointsLocked Int?
+  reservedAt        DateTime?
+  purchasedAt       DateTime?
+  deliveredAt       DateTime?
+  receivedAt        DateTime?
+  createdAt         DateTime    @default(now())
+  updatedAt         DateTime    @updatedAt
+  wishlistItem      WishlistItem @relation(fields: [wishlistItemId], references: [id])
+  giver             User?        @relation(fields: [giverId], references: [id])
+
+  @@index([wishlistItemId])
+}
+
+enum Priority {
+  LOW
+  MEDIUM
+  HIGH
+}
+
+enum GiftStatus {
+  PENDING
+  RESERVED
+  PURCHASED
+  DELIVERED
+  RECEIVED
 }
 
 // Test Plan:

--- a/backend/tests/giftLifecycle.test.js
+++ b/backend/tests/giftLifecycle.test.js
@@ -1,0 +1,206 @@
+import { before, beforeEach, after, test } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+import fs from "node:fs/promises";
+import { randomUUID } from "node:crypto";
+
+const testDir = path.dirname(fileURLToPath(import.meta.url));
+const backendRoot = path.resolve(testDir, "..");
+const prismaDir = path.join(backendRoot, "prisma");
+const testDbPath = path.join(prismaDir, "test.db");
+
+let app;
+let prisma;
+
+before(async () => {
+  process.env.NODE_ENV = "test";
+  process.env.DATABASE_URL = `file:${testDbPath}`;
+
+  try {
+    await fs.unlink(testDbPath);
+  } catch (error) {
+    if (error.code !== "ENOENT") {
+      throw error;
+    }
+  }
+
+  execFileSync(
+    "npx",
+    ["prisma", "migrate", "reset", "--force", "--skip-seed", "--skip-generate"],
+    {
+      cwd: backendRoot,
+      env: { ...process.env, DATABASE_URL: `file:${testDbPath}` },
+      stdio: "inherit",
+    },
+  );
+
+  const serverModule = await import("../server.js");
+  app = serverModule.app;
+  await app.ready();
+  ({ default: prisma } = await import("../prisma/prisma.js"));
+});
+
+beforeEach(async () => {
+  await prisma.gift.deleteMany();
+  await prisma.wishlistItem.deleteMany();
+  await prisma.space.deleteMany();
+  await prisma.user.deleteMany();
+});
+
+after(async () => {
+  if (app) {
+    await app.close();
+  }
+  if (prisma) {
+    await prisma.$disconnect();
+  }
+  try {
+    await fs.unlink(testDbPath);
+  } catch (error) {
+    if (error.code !== "ENOENT") {
+      throw error;
+    }
+  }
+});
+
+async function createSpace(mode = "price") {
+  const inviteCode = `INV-${randomUUID().replace(/-/g, "").slice(0, 8).toUpperCase()}`;
+  const joinCode = randomUUID().replace(/-/g, "").slice(0, 6).toUpperCase();
+  return prisma.space.create({
+    data: {
+      name: `${mode}-space`,
+      description: null,
+      inviteCode,
+      joinCode,
+      mode,
+    },
+  });
+}
+
+async function createUser(emailPrefix) {
+  return prisma.user.create({
+    data: {
+      name: `${emailPrefix} User`,
+      email: `${emailPrefix}-${randomUUID()}@example.com`,
+    },
+  });
+}
+
+test("wishlist lifecycle awards price-indexed points", async () => {
+  const [space, user] = await Promise.all([createSpace("price"), createUser("price")]);
+
+  const createResponse = await app.inject({
+    method: "POST",
+    url: "/wishlist",
+    payload: {
+      spaceId: space.id,
+      title: "Coffee Grinder",
+      priceCents: 2599,
+      priority: "high",
+      notes: "Prefer burr grinder",
+    },
+  });
+
+  assert.equal(createResponse.statusCode, 201);
+  const createdItem = createResponse.json();
+  assert.equal(createdItem.title, "Coffee Grinder");
+  assert.equal(createdItem.priority, "HIGH");
+  assert.ok(createdItem.gift);
+
+  const giftId = createdItem.gift.id;
+
+  const reserveResponse = await app.inject({
+    method: "POST",
+    url: `/gift/${giftId}/reserve`,
+    payload: { giverId: user.id },
+  });
+  assert.equal(reserveResponse.statusCode, 200);
+  assert.equal(reserveResponse.json().status, "RESERVED");
+
+  const purchaseResponse = await app.inject({
+    method: "POST",
+    url: `/gift/${giftId}/purchase`,
+    payload: {},
+  });
+  assert.equal(purchaseResponse.statusCode, 200);
+  assert.equal(purchaseResponse.json().status, "PURCHASED");
+
+  const deliverResponse = await app.inject({
+    method: "POST",
+    url: `/gift/${giftId}/deliver`,
+  });
+  assert.equal(deliverResponse.statusCode, 200);
+  assert.equal(deliverResponse.json().status, "DELIVERED");
+
+  const receiveResponse = await app.inject({
+    method: "POST",
+    url: `/gift/${giftId}/receive`,
+  });
+  assert.equal(receiveResponse.statusCode, 200);
+  const receiveBody = receiveResponse.json();
+  assert.equal(receiveBody.status, "RECEIVED");
+  assert.equal(receiveBody.mode, "PRICE");
+  assert.equal(receiveBody.pointsAwarded, 26);
+
+  const listResponse = await app.inject({
+    method: "GET",
+    url: `/wishlist?spaceId=${space.id}`,
+  });
+  assert.equal(listResponse.statusCode, 200);
+  const list = listResponse.json();
+  assert.equal(list.length, 1);
+  assert.equal(list[0].gift.status, "RECEIVED");
+});
+
+test("sentiment-valued spaces require sentiment points on receive", async () => {
+  const [space, user] = await Promise.all([createSpace("sentiment"), createUser("sentiment")]);
+
+  const createResponse = await app.inject({
+    method: "POST",
+    url: "/wishlist",
+    payload: {
+      spaceId: space.id,
+      title: "Handwritten Letter",
+      priority: "medium",
+    },
+  });
+
+  assert.equal(createResponse.statusCode, 201);
+  const giftId = createResponse.json().gift.id;
+
+  const reserveResponse = await app.inject({
+    method: "POST",
+    url: `/gift/${giftId}/reserve`,
+    payload: { giverId: user.id },
+  });
+  assert.equal(reserveResponse.statusCode, 200);
+
+  const purchaseResponse = await app.inject({
+    method: "POST",
+    url: `/gift/${giftId}/purchase`,
+    payload: {},
+  });
+  assert.equal(purchaseResponse.statusCode, 200);
+
+  const deliverResponse = await app.inject({ method: "POST", url: `/gift/${giftId}/deliver` });
+  assert.equal(deliverResponse.statusCode, 200);
+
+  const missingSentiment = await app.inject({
+    method: "POST",
+    url: `/gift/${giftId}/receive`,
+    payload: {},
+  });
+  assert.equal(missingSentiment.statusCode, 400);
+
+  const receiveResponse = await app.inject({
+    method: "POST",
+    url: `/gift/${giftId}/receive`,
+    payload: { sentimentPoints: 17 },
+  });
+  assert.equal(receiveResponse.statusCode, 200);
+  const body = receiveResponse.json();
+  assert.equal(body.mode, "SENTIMENT");
+  assert.equal(body.pointsAwarded, 17);
+});

--- a/backend/tests/giftPoints.test.js
+++ b/backend/tests/giftPoints.test.js
@@ -1,0 +1,37 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { resolvePointsForGift, roundPriceToPoints } from "../lib/giftPoints.js";
+
+test("roundPriceToPoints normalizes cents to whole points", () => {
+  assert.equal(roundPriceToPoints(2599), 26);
+  assert.equal(roundPriceToPoints(2500), 25);
+  assert.equal(roundPriceToPoints(0), 0);
+  assert.equal(roundPriceToPoints(-100), 0);
+});
+
+test("resolvePointsForGift prefers locked price points when present", () => {
+  const result = resolvePointsForGift(
+    "price",
+    { pricePointsLocked: 18 },
+    { priceCents: 4200 },
+  );
+  assert.deepEqual(result, { points: 18, mode: "PRICE" });
+});
+
+test("resolvePointsForGift falls back to wishlist price when no lock is set", () => {
+  const result = resolvePointsForGift(
+    "price",
+    { pricePointsLocked: null },
+    { priceCents: 3499 },
+  );
+  assert.deepEqual(result, { points: 35, mode: "PRICE" });
+});
+
+test("resolvePointsForGift uses sentiment values when in sentiment mode", () => {
+  const result = resolvePointsForGift(
+    "sentiment",
+    { sentimentPoints: 14 },
+    { priceCents: 9900 },
+  );
+  assert.deepEqual(result, { points: 14, mode: "SENTIMENT" });
+});


### PR DESCRIPTION
## Summary
- add WishlistItem and updated Gift models with lifecycle metadata and enums in Prisma
- introduce URL metadata ingestion and point calculation helpers for wishlist creation and gift completion
- expose REST endpoints for wishlist CRUD and gift lifecycle transitions with validation plus node-based tests and backend README docs

## Testing
- `npm test`

## cURL Examples
```bash
# Create a wishlist item
curl -X POST http://localhost:3000/wishlist \
  -H 'Content-Type: application/json' \
  -d '{"spaceId":1,"title":"Coffee Grinder","priceCents":2599,"priority":"high"}'

# List wishlist items for a space
curl "http://localhost:3000/wishlist?spaceId=1&priority=HIGH&archived=false"

# Update wishlist notes / archive flag
curl -X PATCH http://localhost:3000/wishlist/42 \
  -H 'Content-Type: application/json' \
  -d '{"notes":"Updated note","archived":true}'

# Reserve a gift
curl -X POST http://localhost:3000/gift/42/reserve \
  -H 'Content-Type: application/json' \
  -d '{"giverId":7}'

# Mark a gift as purchased (optional price override in cents)
curl -X POST http://localhost:3000/gift/42/purchase \
  -H 'Content-Type: application/json' \
  -d '{"priceCents":2899}'

# Mark a gift as delivered
curl -X POST http://localhost:3000/gift/42/deliver

# Receive a gift (sentiment mode would include sentimentPoints)
curl -X POST http://localhost:3000/gift/42/receive \
  -H 'Content-Type: application/json' \
  -d '{}'
```

------
https://chatgpt.com/codex/tasks/task_b_68fd554e8558832bb396eb5c24aa123e